### PR TITLE
update overwrite version 1.5.2

### DIFF
--- a/UlrichBerntien/00_test_same_directory.log
+++ b/UlrichBerntien/00_test_same_directory.log
@@ -1,30 +1,176 @@
 [.] overwrite version
-
-Overwrite Version 1.5.1 2019-11-14
+Overwrite Version 1.5.2 2019-11-16
 [.] Create a small test drive
-256+0 records in
-256+0 records out
-262144 bytes (262 kB, 256 KiB) copied, 0,000584544 s, 448 MB/s
-[.] Create FAT file system and mount
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00422954 s, 992 MB/s
+[.] Create fat file system and mount
 mkfs.fat 4.1 (2017-01-24)
 [.] Create 10 test files in the root directory
 total 36
 drwxr-x---  2 root root 16384 Jan  1  1970 .
-drwxrwxrwt 16 root root   380 Nov 15 07:26 ..
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI10.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI1.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI2.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI3.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI4.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI5.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI6.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI7.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI8.txt
--rwxr-x---  1 root root     8 Nov 15 07:26 FRGNTHI9.txt
+drwxrwxrwt 14 root root   340 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI10.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI1.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI2.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI3.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI4.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI5.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI6.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI7.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI8.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI9.txt
 [.] delete the 10 test files
 total 16
 drwxr-x---  2 root root 16384 Jan  1  1970 .
-drwxrwxrwt 16 root root   380 Nov 15 07:26 ..
+drwxrwxrwt 14 root root   340 Nov 18 19:22 ..
+[.] run overwrite program with -meta:20 to overwrite 10 entries
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.4 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00212865 s, 2,0 GB/s
+[.] Create exfat file system and mount
+mkexfatfs 1.2.8
+Creating... done.
+Flushing... done.
+File system created successfully.
+[.] Create 10 test files in the root directory
+total 44
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI10.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI1.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI2.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI3.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI4.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI5.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI6.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI7.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI8.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI9.txt
+[.] delete the 10 test files
+total 4
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+[.] run overwrite program with -meta:20 to overwrite 10 entries
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.3 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00176985 s, 2,4 GB/s
+[.] Create vfat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create 10 test files in the root directory
+total 36
+drwxr-x---  2 root root 16384 Jan  1  1970 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI10.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI1.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI2.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI3.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI4.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI5.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI6.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI7.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI8.txt
+-rwxr-x---  1 root root     8 Nov 18 19:22 FRGNTHI9.txt
+[.] delete the 10 test files
+total 16
+drwxr-x---  2 root root 16384 Jan  1  1970 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+[.] run overwrite program with -meta:20 to overwrite 10 entries
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.4 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,0014837 s, 2,8 GB/s
+[.] Create ext2 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype sparse_super large_file
+[.] Create 10 test files in the root directory
+total 23
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI10.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI1.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI2.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI3.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI4.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI5.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI6.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI7.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI8.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI9.txt
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+[.] delete the 10 test files
+total 13
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+[.] run overwrite program with -meta:20 to overwrite 10 entries
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.3 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,0028799 s, 1,5 GB/s
+[.] Create ext4 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
+[.] Create 10 test files in the root directory
+total 23
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI10.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI1.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI2.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI3.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI4.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI5.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI6.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI7.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI8.txt
+-rw-r-----  1 root root     8 Nov 18 19:22 FRGNTHI9.txt
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+[.] delete the 10 test files
+total 13
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
 [.] run overwrite program with -meta:20 to overwrite 10 entries
 
 Writing metadata: 
@@ -33,6 +179,48 @@ Writing metadata:
 Time: 00:00:00.2 
 Done. 
 [.] unmount the test file system
-[.] check the metadata, read the directory block
-[O] passed. No file name rest found
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00149777 s, 2,8 GB/s
+[.] Create ntfs file system and mount
+/tmp/RAWdata is not a block device.
+mkntfs forced anyway.
+The sector size was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 512 bytes.
+The partition start sector was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of sectors per track was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of heads was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+To boot from a device, Windows needs the 'partition start sector', the 'sectors per track' and the 'number of heads' to be set.
+Windows will not be able to boot from this device.
+[.] Create 10 test files in the root directory
+total 9
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI10.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI1.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI2.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI3.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI4.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI5.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI6.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI7.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI8.txt
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 FRGNTHI9.txt
+[.] delete the 10 test files
+total 4
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+[.] run overwrite program with -meta:20 to overwrite 10 entries
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.4 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
 [.] clean up

--- a/UlrichBerntien/00_test_same_directory.sh
+++ b/UlrichBerntien/00_test_same_directory.sh
@@ -1,52 +1,63 @@
 #!/usr/bin/env bash
+set -o nounset
 
 RAW='/tmp/RAWdata'
 FS='/tmp/testfs'
 
-if [[ $EUID != 0 ]]; then
-    echo "[!] mount/unmount operations needs root privilege"
+if [[ $EUID -ne 0 ]]; then
+    echo '[!] mount/unmount operations needs root privilege'
     exit
 fi
-if [[ ! -x ./overwrite ]]; then
-    ./load_overwrite.sh
-fi
-echo '[.] overwrite version'
-./overwrite --version
+./load_overwrite.sh
 
-echo '[.] Create a small test drive'
-dd bs=1k count=256 if=/dev/zero of=$RAW
-echo '[.] Create FAT file system and mount'
-mkfs.fat $RAW
-mkdir $FS
-mount $RAW $FS
-
-echo '[.] Create 10 test files in the root directory'
-for i in $(seq 10)
+for mkfs in 'fat' 'exfat' 'vfat' 'ext2' 'ext4' 'ntfs'
 do
-    echo 'content' > $FS/FRGNTHI$i.txt
+    echo '[.] Create a small test drive'
+    dd bs=1M count=4 if=/dev/zero "of=$RAW"
+    echo "[.] Create $mkfs file system and mount"
+    if [[ "$mkfs" =~ 'ext' ]]; then
+        mkfs.$mkfs -q -O ^has_journal "$RAW"
+        tune2fs -l "$RAW" | grep -iE '(features|journal)'
+    elif [[ "$mkfs" == 'ntfs' ]]; then
+        mkfs.$mkfs -q -F "$RAW"
+    else
+        mkfs.$mkfs "$RAW"
+    fi
+    mkdir "$FS"
+    mount "$RAW" "$FS"
+
+    echo '[.] Create 10 test files in the root directory'
+    for i in $(seq 10)
+    do
+        echo 'content' > "$FS/FRGNTHI$i.txt"
+    done
+    ls -al $FS
+    echo '[.] delete the 10 test files'
+    rm $FS/FRGNTHI*.txt
+    ls -al "$FS"
+
+    echo '[.] run overwrite program with -meta:20 to overwrite 10 entries'
+    # Differences between number in -meta and number of overwrites is
+    # in the documentation.
+    ./overwrite -meta:20 -path:$FS/
+
+    echo '[.] unmount the test file system'
+    umount "$FS"
+    # extract strings in 16-bit little endian 
+    strings -n 6 -e l $RAW > /tmp/strs
+
+    echo '[.] check the metadata'
+    if grep -qF RGNTHI $RAW; then
+        echo '[X] file name rest found on test drive!'
+        hexdump -C $RAW | grep -F RGNTHI
+    elif grep -qF RGNTHI /tmp/strs; then
+        echo '[X] file name rest (2 byte charset) found on test drive!'
+        grep -F RGNTHI /tmp/strs
+    else
+        echo '[O] test case passed. No file name rest found'
+    fi
+
+    echo '[.] clean up'
+    rmdir "$FS"
+    rm "$RAW"
 done
-ls -al $FS
-echo '[.] delete the 10 test files'
-rm $FS/FRGNTHI*.txt
-ls -al $FS
-
-echo '[.] run overwrite program with -meta:20 to overwrite 10 entries'
-# Differences between number in -meta and number of overwrites is
-# in the documentation.
-./overwrite -meta:20 -path:$FS/
-
-echo '[.] unmount the test file system'
-sync -f $FS
-umount $FS
-
-echo '[.] check the metadata, read the directory block'
-if grep 'RGNTHI' $RAW; then
-    echo '[X] file name rest found on test drive!'
-    hexdump -s 1536 -n 768 -C $RAW
-else
-    echo '[O] passed. No file name rest found'
-fi
-
-echo '[.] clean up'
-rmdir $FS
-rm $RAW

--- a/UlrichBerntien/01_test_short_names.log
+++ b/UlrichBerntien/01_test_short_names.log
@@ -1,104 +1,184 @@
 [.] overwrite version
-
-Overwrite Version 1.5.1 2019-11-14
+Overwrite Version 1.5.2 2019-11-16
 [.] Create a small test drive
-256+0 records in
-256+0 records out
-262144 bytes (262 kB, 256 KiB) copied, 0,0010177 s, 258 MB/s
-[.] Create FAT file system and mount
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00168301 s, 2,5 GB/s
+[.] Create fat file system and mount
 mkfs.fat 4.1 (2017-01-24)
 [.] Create 2 short name test files in the root directory
 total 20
 drwxr-x---  2 root root 16384 Jan  1  1970 .
-drwxrwxrwt 16 root root   380 Nov 15 07:26 ..
--rwxr-x---  1 root root     8 Nov 15 07:26 1FIRST1.TXT
--rwxr-x---  1 root root     8 Nov 15 07:26 SECOND.TXT
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 1FIRST1.TXT
+-rwxr-x---  1 root root     8 Nov 18 19:22 SECOND.TXT
 [.] delete the first file only, NOT the second file
 total 18
 drwxr-x---  2 root root 16384 Jan  1  1970 .
-drwxrwxrwt 16 root root   380 Nov 15 07:26 ..
--rwxr-x---  1 root root     8 Nov 15 07:26 SECOND.TXT
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 SECOND.TXT
 [.] run overwrite program
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
-Writing data: 
-100% 
+
+Time: 00:00:00.1 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00144147 s, 2,9 GB/s
+[.] Create exfat file system and mount
+mkexfatfs 1.2.8
+Creating... done.
+Flushing... done.
+File system created successfully.
+[.] Create 2 short name test files in the root directory
+total 12
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 1FIRST1.TXT
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 SECOND.TXT
+[.] delete the first file only, NOT the second file
+total 8
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 SECOND.TXT
+[.] run overwrite program
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.2 
 Done. 
 [.] unmount the test file system
-[.] check the metadata, read the directory block
-[X] file name rest of FIRST file found on test drive!
-00000000  eb 3c 90 6d 6b 66 73 2e  66 61 74 00 02 04 01 00  |.<.mkfs.fat.....|
-00000010  02 00 02 00 02 f8 01 00  20 00 40 00 00 00 00 00  |........ .@.....|
-00000020  00 00 00 00 80 00 29 5d  76 52 52 4e 4f 20 4e 41  |......)]vRRNO NA|
-00000030  4d 45 20 20 20 20 46 41  54 31 32 20 20 20 0e 1f  |ME    FAT12   ..|
-00000040  be 5b 7c ac 22 c0 74 0b  56 b4 0e bb 07 00 cd 10  |.[|.".t.V.......|
-00000050  5e eb f0 32 e4 cd 16 cd  19 eb fe 54 68 69 73 20  |^..2.......This |
-00000060  69 73 20 6e 6f 74 20 61  20 62 6f 6f 74 61 62 6c  |is not a bootabl|
-00000070  65 20 64 69 73 6b 2e 20  20 50 6c 65 61 73 65 20  |e disk.  Please |
-00000080  69 6e 73 65 72 74 20 61  20 62 6f 6f 74 61 62 6c  |insert a bootabl|
-00000090  65 20 66 6c 6f 70 70 79  20 61 6e 64 0d 0a 70 72  |e floppy and..pr|
-000000a0  65 73 73 20 61 6e 79 20  6b 65 79 20 74 6f 20 74  |ess any key to t|
-000000b0  72 79 20 61 67 61 69 6e  20 2e 2e 2e 20 0d 0a 00  |ry again ... ...|
-000000c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000001f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 55 aa  |..............U.|
-00000200  f8 ff ff 00 00 00 ff 0f  00 00 00 00 00 00 00 00  |................|
-00000210  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00000400  f8 ff ff 00 00 00 ff 0f  00 00 00 00 00 00 00 00  |................|
-00000410  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00000600  e5 46 49 52 53 54 31 20  54 58 54 20 00 76 56 33  |.FIRST1 TXT .vV3|
-00000610  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000620  53 45 43 4f 4e 44 20 20  54 58 54 20 00 76 56 33  |SECOND  TXT .vV3|
-00000630  6f 4f 6f 4f 00 00 56 33  6f 4f 04 00 08 00 00 00  |oOoO..V3oO......|
-00000640  e5 30 00 78 00 2d 00 00  00 ff ff 0f 00 65 ff ff  |.0.x.-.......e..|
-00000650  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-00000660  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-00000670  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000680  e5 32 00 78 00 2d 00 00  00 ff ff 0f 00 e3 ff ff  |.2.x.-..........|
-00000690  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-000006a0  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-000006b0  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-000006c0  e5 33 00 78 00 2d 00 00  00 ff ff 0f 00 a4 ff ff  |.3.x.-..........|
-000006d0  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-000006e0  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-000006f0  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000700  e5 34 00 78 00 2d 00 00  00 ff ff 0f 00 5e ff ff  |.4.x.-.......^..|
-00000710  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-00000720  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-00000730  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000740  e5 35 00 78 00 2d 00 00  00 ff ff 0f 00 9e ff ff  |.5.x.-..........|
-00000750  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-00000760  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-00000770  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000780  e5 36 00 78 00 2d 00 00  00 ff ff 0f 00 de ff ff  |.6.x.-..........|
-00000790  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-000007a0  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-000007b0  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-000007c0  e5 37 00 78 00 2d 00 00  00 ff ff 0f 00 a5 ff ff  |.7.x.-..........|
-000007d0  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-000007e0  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-000007f0  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000800  e5 38 00 78 00 2d 00 00  00 ff ff 0f 00 63 ff ff  |.8.x.-.......c..|
-00000810  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-00000820  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-00000830  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000840  e5 39 00 78 00 2d 00 00  00 ff ff 0f 00 23 ff ff  |.9.x.-.......#..|
-00000850  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-00000860  e5 58 2d 20 20 20 20 20  20 20 20 20 00 78 56 33  |.X-         .xV3|
-00000870  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-00000880  e5 31 00 30 00 78 00 2d  00 00 00 0f 00 ce ff ff  |.1.0.x.-........|
-00000890  ff ff ff ff ff ff ff ff  ff ff 00 00 ff ff ff ff  |................|
-000008a0  e5 30 58 2d 20 20 20 20  20 20 20 20 00 78 56 33  |.0X-        .xV3|
-000008b0  6f 4f 6f 4f 00 00 56 33  6f 4f 00 00 00 00 00 00  |oOoO..V3oO......|
-000008c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00005600  63 6f 6e 74 65 6e 74 0a  00 00 00 00 00 00 00 00  |content.........|
-00005610  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00040000
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00231241 s, 1,8 GB/s
+[.] Create vfat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create 2 short name test files in the root directory
+total 20
+drwxr-x---  2 root root 16384 Jan  1  1970 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 1FIRST1.TXT
+-rwxr-x---  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] delete the first file only, NOT the second file
+total 18
+drwxr-x---  2 root root 16384 Jan  1  1970 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rwxr-x---  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] run overwrite program
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.2 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00145315 s, 2,9 GB/s
+[.] Create ext2 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype sparse_super large_file
+[.] Create 2 short name test files in the root directory
+total 15
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rw-r-----  1 root root     8 Nov 18 19:22 1FIRST1.TXT
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+-rw-r-----  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] delete the first file only, NOT the second file
+total 14
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+-rw-r-----  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] run overwrite program
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.1 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00222772 s, 1,9 GB/s
+[.] Create ext4 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
+[.] Create 2 short name test files in the root directory
+total 15
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+-rw-r-----  1 root root     8 Nov 18 19:22 1FIRST1.TXT
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+-rw-r-----  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] delete the first file only, NOT the second file
+total 14
+drwxr-xr-x  3 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+-rw-r-----  1 root root     8 Nov 18 19:22 SECOND.TXT
+[.] run overwrite program
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.1 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+4+0 records in
+4+0 records out
+4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,00299299 s, 1,4 GB/s
+[.] Create ntfs file system and mount
+/tmp/RAWdata is not a block device.
+mkntfs forced anyway.
+The sector size was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 512 bytes.
+The partition start sector was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of sectors per track was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of heads was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+To boot from a device, Windows needs the 'partition start sector', the 'sectors per track' and the 'number of heads' to be set.
+Windows will not be able to boot from this device.
+[.] Create 2 short name test files in the root directory
+total 5
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 1FIRST1.TXT
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 SECOND.TXT
+[.] delete the first file only, NOT the second file
+total 5
+drwxrwxrwx  1 root root 4096 Nov 18 19:22 .
+drwxrwxrwt 14 root root  360 Nov 18 19:22 ..
+-rwxrwxrwx  1 root root    8 Nov 18 19:22 SECOND.TXT
+[.] run overwrite program
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+
+Time: 00:00:00.2 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
 [.] clean up

--- a/UlrichBerntien/01_test_short_names.sh
+++ b/UlrichBerntien/01_test_short_names.sh
@@ -1,46 +1,59 @@
 #!/usr/bin/env bash
+set -o nounset
 
 RAW='/tmp/RAWdata'
 FS='/tmp/testfs'
 
-if [[ $EUID != 0 ]]; then
-    echo "[!] mount/unmount operations needs root privilege"
+if [[ $EUID -ne 0 ]]; then
+    echo '[!] mount/unmount operations needs root privilege'
     exit
-fi
-if [[ ! -x ./overwrite ]]; then
-    ./load_overwrite.sh
-fi
-echo '[.] overwrite version'
-./overwrite --version
+fi    
+./load_overwrite.sh
 
-echo '[.] Create a small test drive'
-dd bs=1k count=256 if=/dev/zero "of=$RAW"
-echo '[.] Create FAT file system and mount'
-mkfs.fat "$RAW"
-mkdir "$FS"
-mount "$RAW" "$FS"
+for mkfs in 'fat' 'exfat' 'vfat' 'ext2' 'ext4' 'ntfs'
+do
+    echo '[.] Create a small test drive'
+    dd bs=1M count=4 if=/dev/zero "of=$RAW"
+    echo "[.] Create $mkfs file system and mount"
+    if [[ "$mkfs" =~ 'ext' ]]; then
+        mkfs.$mkfs -q -O ^has_journal "$RAW"
+        tune2fs -l "$RAW" | grep -iE '(features|journal)'
+    elif [[ "$mkfs" == 'ntfs' ]]; then
+        mkfs.$mkfs -q -F "$RAW"
+    else
+        mkfs.$mkfs "$RAW"
+    fi
+    mkdir "$FS"
+    mount "$RAW" "$FS"
 
-echo '[.] Create 2 short name test files in the root directory'
-echo 'content' > $FS/1FIRST1.TXT
-echo 'content' > $FS/SECOND.TXT
-ls -al "$FS"
-echo '[.] delete the first file only, NOT the second file'
-rm $FS/1FIRST1.TXT
-ls -al "$FS"
+    echo '[.] Create 2 short name test files in the root directory'
+    echo 'content' > $FS/1FIRST1.TXT
+    echo 'content' > $FS/SECOND.TXT
+    ls -al "$FS"
+    echo '[.] delete the first file only, NOT the second file'
+    rm $FS/1FIRST1.TXT
+    ls -al "$FS"
 
-echo '[.] run overwrite program'
-./overwrite -block:512 -meta:10 -data:10mb -path:$FS/
+    echo '[.] run overwrite program'
+    ./overwrite -meta:10 -path:$FS/
 
-echo '[.] unmount the test file system'
-umount "$FS"
+    echo '[.] unmount the test file system'
+    umount "$FS"
+    # extract strings in 16-bit little endian 
+    strings -n 5 -e l $RAW > /tmp/strs
 
-echo '[.] check the metadata, read the directory block'
-if grep -qF 'FIRST' $RAW; then
-    echo '[X] file name rest of FIRST file found on test drive!'
-    hexdump -C $RAW 
-else
-    echo '[O] passed. No file name rest found'
-fi
-echo '[.] clean up'
-rm -rf "$FS"
-rm "$RAW"
+    echo '[.] check the metadata'
+    if grep -qF FIRST $RAW; then
+        echo '[X] file name rest found on test drive!'
+        hexdump -C $RAW | grep -F FIRST
+    elif grep -qF FIRST /tmp/strs; then
+        echo '[X] file name rest (2 byte charset) found on test drive!'
+        grep -F FIRST /tmp/strs
+    else
+        echo '[O] test case passed. No file name rest found'
+    fi
+    
+    echo '[.] clean up'
+    rm -rf "$FS"
+    rm "$RAW"
+done

--- a/UlrichBerntien/02_test_overflow.log
+++ b/UlrichBerntien/02_test_overflow.log
@@ -1,8 +1,10 @@
 [.] overwrite version
-
-Overwrite Version 1.5.1 2019-11-14
+Overwrite Version 1.5.2 2019-11-16
 [.] Generate very long argument
 [.] path argument lenth is 1024
 [.] run overwrite program with very long argument
-././02_test_overflow.sh: line 19:  6769 Segmentation fault      (core dumped) ./overwrite -meta:1 -path:$FLONG 2>&1
-[X] missing error message
+
+Writing metadata: 
+Error 36, File name too long. 
+Error writing metadata file. 
+[0] error message found, test passed

--- a/UlrichBerntien/02_test_overflow.sh
+++ b/UlrichBerntien/02_test_overflow.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
+set -o nounset
 
-if [[ ! -x ./overwrite ]]; then
-    ./load_overwrite.sh
-fi
-echo '[.] overwrite version'
-./overwrite --version
+./load_overwrite.sh
 
 echo '[.] Generate very long argument'
 # current PATH_MAX is 4096 in Linux.
 FLONG="x"
-for i in $(seq 10); do
+for _ in $(seq 10); do
     FLONG=$FLONG$FLONG
 done
 

--- a/UlrichBerntien/03_test_unix_names.log
+++ b/UlrichBerntien/03_test_unix_names.log
@@ -1,69 +1,68 @@
 [.] overwrite version
-
-Overwrite Version 1.5.1 2019-11-14
+Overwrite Version 1.5.2 2019-11-16
 [.] Create a small test drive
 1+0 records in
 1+0 records out
-524288 bytes (524 kB, 512 KiB) copied, 0,00037009 s, 1,4 GB/s
+524288 bytes (524 kB, 512 KiB) copied, 0,000733728 s, 715 MB/s
 [.] Create ext4 file system and mount
 
 Filesystem too small for a journal
 [.] Create test directories
 total 20
-dr-xr-xr-x 10 root root  1024 Nov 15 07:26 .
-drwxrwxrwt 16 root root   380 Nov 15 07:26 ..
-drwxr-x---  2 root root  1024 Nov 15 07:26 backslash\\
-drwxr-x---  2 root root  1024 Nov 15 07:26 colon:
-drwx------  2 root root 12288 Nov 15 07:26 lost+found
-drwxr-x---  2 root root  1024 Nov 15 07:26 simple
-drwxr-x---  2 root root  1024 Nov 15 07:26 space
-drwxr-x---  2 root root  1024 Nov 15 07:26 spaceend 
-drwxr-x---  2 root root  1024 Nov 15 07:26 space in
-drwxr-x---  2 root root  1024 Nov 15 07:26 unicode̷ 
+dr-xr-xr-x 10 root root  1024 Nov 18 19:22 .
+drwxrwxrwt 14 root root   360 Nov 18 19:22 ..
+drwxr-x---  2 root root  1024 Nov 18 19:22 backslash\\
+drwxr-x---  2 root root  1024 Nov 18 19:22 colon:
+drwx------  2 root root 12288 Nov 18 19:22 lost+found
+drwxr-x---  2 root root  1024 Nov 18 19:22 simple
+drwxr-x---  2 root root  1024 Nov 18 19:22 space
+drwxr-x---  2 root root  1024 Nov 18 19:22 spaceend 
+drwxr-x---  2 root root  1024 Nov 18 19:22 space in
+drwxr-x---  2 root root  1024 Nov 18 19:22 unicode̷ 
 [.] run overwrite program
-[.] call: -meta:10 -path:/tmp/testfs/simple
+[.] call overwrite -meta:10 -path:/tmp/testfs/simple
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/colon:
+[.] call overwrite -meta:10 -path:/tmp/testfs/colon:
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/backslash\\
+[.] call overwrite -meta:10 -path:/tmp/testfs/backslash\\
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/unicode̷ 
+[.] call overwrite -meta:10 -path:/tmp/testfs/unicode̷ 
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/space
+[.] call overwrite -meta:10 -path:/tmp/testfs/space
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/spaceend 
+[.] call overwrite -meta:10 -path:/tmp/testfs/spaceend 
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 
 Time: 00:00:00.1 
 Done. 
-[.] call: -meta:10 -path:/tmp/testfs/space in
+[.] call overwrite -meta:10 -path:/tmp/testfs/space in
 
 Writing metadata: 
 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 

--- a/UlrichBerntien/03_test_unix_names.sh
+++ b/UlrichBerntien/03_test_unix_names.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o nounset
 
 RAW='/tmp/RAWdata'
 FS='/tmp/testfs'
@@ -6,15 +7,11 @@ FS='/tmp/testfs'
 # Some directory to test
 UNIX_DIR_NAMES=('simple' 'colon:' 'backslash\\' 'unicode̷ ' 'space' 'spaceend ' 'space in')
 
-if [[ $EUID != 0 ]]; then
-    echo "[!] mount/unmount operations needs root privilege"
+if [[ $EUID -ne 0 ]]; then
+    echo '[!] mount/unmount operations needs root privilege'
     exit
-fi
-if [[ ! -x ./overwrite ]]; then
-    ./load_overwrite.sh
-fi
-echo '[.] overwrite version'
-./overwrite --version
+fi    
+./load_overwrite.sh
 
 echo '[.] Create a small test drive'
 dd bs=512k count=1 if=/dev/zero "of=$RAW"
@@ -40,12 +37,11 @@ do
     # use absolute path name because overwrite does not handle path names
     # starting with a space.
     OV_ARGUMENTS=("-meta:10" "-path:$FS/$name")
-    echo "[.] call: ${OV_ARGUMENTS[@]}"
+    echo '[.] call overwrite' "${OV_ARGUMENTS[@]}"
     ./overwrite "${OV_ARGUMENTS[@]}"
 done
 
 echo '[.] unmount the test file system'
-sync -f "$FS"
 umount "$FS"
 
 echo '[.] check the data on the test drive'

--- a/UlrichBerntien/04_ext4_file_names.log
+++ b/UlrichBerntien/04_ext4_file_names.log
@@ -1,56 +1,137 @@
 [.] overwrite version
-
-Overwrite Version 1.5.1 2019-11-14
+Overwrite Version 1.5.2 2019-11-16
 [.] Create a small test drive
-1+0 records in
-1+0 records out
-1048576 bytes (1,0 MB, 1,0 MiB) copied, 0,00106061 s, 989 MB/s
-[.] Create ext4 file system with out JOURNAL
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,00868135 s, 2,9 GB/s
+[.] Create fat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create test files
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+total 18
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+[.] Delete all test files
+total 0
+[.] run overwrite -meta:70 -data:all -path:/tmp/testfs
 
-Filesystem too small for a journal
-tune2fs 1.44.1 (24-Mar-2018)
-Filesystem volume name:   <none>
-Last mounted on:          <not available>
-Filesystem UUID:          d50f1cd4-ddab-4c28-8f0d-f276b073ff09
-Filesystem magic number:  0xEF53
-Filesystem revision #:    1 (dynamic)
-Filesystem features:      ext_attr resize_inode dir_index filetype extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
-Filesystem flags:         signed_directory_hash 
-Default mount options:    user_xattr acl
-Filesystem state:         clean
-Errors behavior:          Continue
-Filesystem OS type:       Linux
-Inode count:              128
-Block count:              1024
-Reserved block count:     51
-Free blocks:              982
-Free inodes:              117
-First block:              1
-Block size:               1024
-Fragment size:            1024
-Group descriptor size:    64
-Reserved GDT blocks:      7
-Blocks per group:         8192
-Fragments per group:      8192
-Inodes per group:         128
-Inode blocks per group:   16
-Flex block group size:    16
-Filesystem created:       Fri Nov 15 07:26:45 2019
-Last mount time:          n/a
-Last write time:          Fri Nov 15 07:26:45 2019
-Mount count:              0
-Maximum mount count:      -1
-Last checked:             Fri Nov 15 07:26:45 2019
-Check interval:           0 (<none>)
-Lifetime writes:          26 kB
-Reserved blocks uid:      0 (user root)
-Reserved blocks gid:      0 (group root)
-First inode:              11
-Inode size:	          128
-Default directory hash:   half_md4
-Directory Hash Seed:      94a4b8a3-ee95-42df-bd69-cb14d0cea60b
-Checksum type:            crc32c
-Checksum:                 0xcdc88611
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+100% 
+
+Time: 00:00:00.61 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,0120165 s, 2,1 GB/s
+[.] Create exfat file system and mount
+mkexfatfs 1.2.8
+Creating... done.
+Flushing... done.
+File system created successfully.
+[.] Create test files
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+total 36
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+[.] Delete all test files
+total 0
+[.] run overwrite -meta:70 -data:all -path:/tmp/testfs
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+100% 
+
+Time: 00:00:00.50 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,0069619 s, 3,6 GB/s
+[.] Create vfat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create test files
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+total 18
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxr-x--- 1 root root 8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+[.] Delete all test files
+total 0
+[.] run overwrite -meta:70 -data:all -path:/tmp/testfs
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+100% 
+
+Time: 00:00:00.61 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,00831974 s, 3,0 GB/s
+[.] Create ext2 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype sparse_super large_file
 [.] Create test files
 [.] test file name length: 46
 [.] test file name length: 46
@@ -62,308 +143,120 @@ Checksum:                 0xcdc88611
 [.] test file name length: 46
 [.] test file name length: 46
 total 21
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
--rw-r----- 1 root root     8 Nov 15 07:26 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
-drwx------ 2 root root 12288 Nov 15 07:26 lost+found
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+drwx------ 2 root root 12288 Nov 18 19:22 lost+found
 [.] Delete all test files
 total 12
-drwx------ 2 root root 12288 Nov 15 07:26 lost+found
-[.] run overwrite with -meta:9000 -data:all -path:/tmp/testfs
+drwx------ 2 root root 12288 Nov 18 19:22 lost+found
+[.] run overwrite -meta:70 -data:all -path:/tmp/testfs
 
 Writing metadata: 
-Error 28, No space left on device. 
-Error writing files. 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
 Writing data: 
 100% 
 
-Time: 00:00:00.19 
+Time: 00:00:00.72 
 Done. 
 [.] unmount the test file system
-[.] check the data on the test drive
-[X] file name rest found on test drive!
-00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00000400  80 00 00 00 00 04 00 00  33 00 00 00 d4 03 00 00  |........3.......|
-00000410  75 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00  |u...............|
-00000420  00 20 00 00 00 20 00 00  80 00 00 00 25 45 ce 5d  |. ... ......%E.]|
-00000430  25 45 ce 5d 01 00 ff ff  53 ef 01 00 01 00 00 00  |%E.]....S.......|
-00000440  25 45 ce 5d 00 00 00 00  00 00 00 00 01 00 00 00  |%E.]............|
-00000450  00 00 00 00 0b 00 00 00  80 00 00 00 38 00 00 00  |............8...|
-00000460  c2 02 00 00 6b 04 00 00  d5 0f 1c d4 dd ab 4c 28  |....k.........L(|
-00000470  8f 0d f2 76 b0 73 ff 09  00 00 00 00 00 00 00 00  |...v.s..........|
-00000480  00 00 00 00 00 00 00 00  2f 74 6d 70 2f 74 65 73  |......../tmp/tes|
-00000490  74 66 73 00 00 00 00 00  00 00 00 00 00 00 00 00  |tfs.............|
-000004a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000004c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 07 00  |................|
-000004d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-000004e0  00 00 00 00 00 00 00 00  00 00 00 00 94 a4 b8 a3  |................|
-000004f0  ee 95 42 df bd 69 cb 14  d0 ce a6 0b 01 00 40 00  |..B..i........@.|
-00000500  0c 00 00 00 00 00 00 00  25 45 ce 5d 00 00 00 00  |........%E.]....|
-00000510  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00000560  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-00000570  00 00 00 00 04 01 00 00  2a 07 00 00 00 00 00 00  |........*.......|
-00000580  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000007f0  00 00 00 00 00 00 00 00  00 00 00 00 a3 d7 d1 a0  |................|
-00000800  0a 00 00 00 1a 00 00 00  2a 00 00 00 d4 03 75 00  |........*.....u.|
-00000810  02 00 04 00 00 00 00 00  f1 91 16 02 00 00 81 c6  |................|
-00000820  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-00000830  00 00 00 00 00 00 00 00  ff b2 65 4f 00 00 00 00  |..........eO....|
-00000840  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00002800  ff ff ff 07 00 fe ff 01  00 00 00 00 00 00 00 00  |................|
-00002810  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00002870  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 80  |................|
-00002880  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
-*
-00002c00  02 00 00 00 0c 00 01 02  2e 00 00 00 02 00 00 00  |................|
-00002c10  f4 03 02 02 2e 2e 00 00  00 00 00 00 01 08 00 00  |................|
-00002c20  7b 00 02 00 01 00 00 00  9a 83 01 66 02 00 00 00  |{..........f....|
-00002c30  6c 00 61 01 e2 88 bc e2  88 bc 31 e2 88 bc e2 88  |l.a.......1.....|
-00002c40  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002c50  9a d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |................|
-00002c60  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002c70  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002c80  9a d0 b5 e2 88 bc e2 88  bc 4d 6f 68 35 7a 61 e2  |.........Moh5za.|
-00002c90  88 bc e2 88 bc 00 00 00  0d 00 00 00 6c 00 61 01  |............l.a.|
-00002ca0  e2 88 bc e2 88 bc 32 e2  88 bc e2 88 bc d1 82 d0  |......2.........|
-00002cb0  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002cc0  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002cd0  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00002ce0  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002cf0  88 bc e2 88 bc 4d 6f 68  35 7a 61 e2 88 bc e2 88  |.....Moh5za.....|
-00002d00  bc 00 00 00 0e 00 00 00  6c 00 61 01 e2 88 bc e2  |........l.a.....|
-00002d10  88 bc 33 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |..3.............|
-00002d20  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002d30  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002d40  9a d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |................|
-00002d50  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002d60  bc 4d 6f 68 35 7a 61 e2  88 bc e2 88 bc 00 00 00  |.Moh5za.........|
-00002d70  0f 00 00 00 6c 00 61 01  e2 88 bc e2 88 bc 34 e2  |....l.a.......4.|
-00002d80  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002d90  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00002da0  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002db0  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002dc0  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc 4d 6f 68  |.............Moh|
-00002dd0  35 7a 61 e2 88 bc e2 88  bc 00 00 00 10 00 00 00  |5za.............|
-00002de0  6c 00 61 01 e2 88 bc e2  88 bc 35 e2 88 bc e2 88  |l.a.......5.....|
-00002df0  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002e00  9a d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |................|
-00002e10  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002e20  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002e30  9a d0 b5 e2 88 bc e2 88  bc 4d 6f 68 35 7a 61 e2  |.........Moh5za.|
-00002e40  88 bc e2 88 bc 00 00 00  11 00 00 00 6c 00 61 01  |............l.a.|
-00002e50  e2 88 bc e2 88 bc 36 e2  88 bc e2 88 bc d1 82 d0  |......6.........|
-00002e60  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002e70  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002e80  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00002e90  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002ea0  88 bc e2 88 bc 4d 6f 68  35 7a 61 e2 88 bc e2 88  |.....Moh5za.....|
-00002eb0  bc 00 00 00 12 00 00 00  6c 00 61 01 e2 88 bc e2  |........l.a.....|
-00002ec0  88 bc 37 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |..7.............|
-00002ed0  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002ee0  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-00002ef0  9a d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |................|
-00002f00  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00002f10  bc 4d 6f 68 35 7a 61 e2  88 bc e2 88 bc 00 00 00  |.Moh5za.........|
-00002f20  13 00 00 00 d4 00 61 01  e2 88 bc e2 88 bc 38 e2  |......a.......8.|
-00002f30  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002f40  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00002f50  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00002f60  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00002f70  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc 4d 6f 68  |.............Moh|
-00002f80  35 7a 61 e2 88 bc e2 88  bc 00 00 00 00 00 00 00  |5za.............|
-00002f90  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00002ff0  00 00 00 00 00 00 00 00  0c 00 00 de 48 c8 30 56  |............H.0V|
-00003000  0b 00 00 00 0c 00 01 02  2e 00 00 00 02 00 00 00  |................|
-00003010  e8 03 02 02 2e 2e 00 00  00 00 00 00 00 00 00 00  |................|
-00003020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000033f0  00 00 00 00 00 00 00 00  0c 00 00 de cc 22 9b db  |............."..|
-00003400  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00003410  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000037f0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00003800  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00003810  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00003bf0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00003c00  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00003c10  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00003ff0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00004000  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00004010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000043f0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00004400  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00004410  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000047f0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00004800  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00004810  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00004bf0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00004c00  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00004c10  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00004ff0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00005000  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00005010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000053f0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00005400  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00005410  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000057f0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00005800  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00005810  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00005bf0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00005c00  00 00 00 00 f4 03 00 00  00 00 00 00 00 00 00 00  |................|
-00005c10  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00005ff0  00 00 00 00 00 00 00 00  0c 00 00 de b2 13 4e 2f  |..............N/|
-00006000  00 00 00 00 f4 03 03 01  30 78 2d e2 12 00 00 00  |........0x-.....|
-00006010  0c 00 03 01 37 78 2d d0  13 00 00 00 0c 00 03 01  |....7x-.........|
-00006020  38 78 2d d1 15 00 00 00  0c 00 04 01 31 30 78 2d  |8x-.........10x-|
-00006030  17 00 00 00 0c 00 04 01  31 32 78 2d 1d 00 00 00  |........12x-....|
-00006040  0c 00 04 01 31 38 78 2d  22 00 00 00 0c 00 04 01  |....18x-".......|
-00006050  32 33 78 2d 24 00 00 00  0c 00 04 01 32 35 78 2d  |23x-$.......25x-|
-00006060  27 00 00 00 0c 00 04 01  32 38 78 2d 2a 00 00 00  |'.......28x-*...|
-00006070  0c 00 04 01 33 31 78 2d  2c 00 00 00 0c 00 04 01  |....31x-,.......|
-00006080  33 33 78 2d 2e 00 00 00  0c 00 04 01 33 35 78 2d  |33x-........35x-|
-00006090  2f 00 00 00 0c 00 04 01  33 36 78 2d 33 00 00 00  |/.......36x-3...|
-000060a0  0c 00 04 01 34 30 78 2d  35 00 00 00 0c 00 04 01  |....40x-5.......|
-000060b0  34 32 78 2d 36 00 00 00  0c 00 04 01 34 33 78 2d  |42x-6.......43x-|
-000060c0  3c 00 00 00 0c 00 04 01  34 39 78 2d 3d 00 00 00  |<.......49x-=...|
-000060d0  0c 00 04 01 35 30 78 2d  40 00 00 00 0c 00 04 01  |....50x-@.......|
-000060e0  35 33 78 2d 42 00 00 00  0c 00 04 01 35 35 78 2d  |53x-B.......55x-|
-000060f0  43 00 00 00 0c 00 04 01  35 36 78 2d 45 00 00 00  |C.......56x-E...|
-00006100  0c 00 04 01 35 38 78 2d  48 00 00 00 0c 00 04 01  |....58x-H.......|
-00006110  36 31 78 2d 4c 00 00 00  0c 00 04 01 36 35 78 2d  |61x-L.......65x-|
-00006120  4d 00 00 00 0c 00 04 01  36 36 78 2d 4f 00 00 00  |M.......66x-O...|
-00006130  0c 00 04 01 36 38 78 2d  50 00 00 00 0c 00 04 01  |....68x-P.......|
-00006140  36 39 78 2d 51 00 00 00  0c 00 04 01 37 30 78 2d  |69x-Q.......70x-|
-00006150  53 00 00 00 0c 00 04 01  37 32 78 2d 54 00 00 00  |S.......72x-T...|
-00006160  0c 00 04 01 37 33 78 2d  5c 00 00 00 0c 00 04 01  |....73x-\.......|
-00006170  38 31 78 2d 63 00 00 00  0c 00 04 01 38 38 78 2d  |81x-c.......88x-|
-00006180  66 00 00 00 0c 00 04 01  39 31 78 2d 67 00 00 00  |f.......91x-g...|
-00006190  0c 00 04 01 39 32 78 2d  68 00 00 00 0c 00 04 01  |....92x-h.......|
-000061a0  39 33 78 2d 71 00 00 00  10 00 05 01 31 30 32 78  |93x-q.......102x|
-000061b0  2d bc e2 88 74 00 00 00  10 00 05 01 31 30 35 78  |-...t.......105x|
-000061c0  2d 00 00 00 79 00 00 00  10 00 05 01 31 31 30 78  |-...y.......110x|
-000061d0  2d bc 35 e2 7c 00 00 00  10 00 05 01 31 31 33 78  |-.5.|.......113x|
-000061e0  2d d0 b8 d1 7d 00 00 00  10 00 05 01 31 31 34 78  |-...}.......114x|
-000061f0  2d d1 82 d0 7f 00 00 00  00 02 05 01 31 31 36 78  |-...........116x|
-00006200  2d d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |-...............|
-00006210  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-00006220  bc 4d 6f 68 35 7a 61 e2  88 bc e2 88 bc 00 00 00  |.Moh5za.........|
-00006230  00 00 00 00 6c 00 61 01  e2 88 bc e2 88 bc 36 e2  |....l.a.......6.|
-00006240  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00006250  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00006260  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00006270  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00006280  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc 4d 6f 68  |.............Moh|
-00006290  35 7a 61 e2 88 bc e2 88  bc 00 00 00 00 00 00 00  |5za.............|
-000062a0  6c 00 61 01 e2 88 bc e2  88 bc 37 e2 88 bc e2 88  |l.a.......7.....|
-000062b0  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-000062c0  9a d0 b5 e2 88 bc e2 88  bc d1 82 d0 b5 d1 81 d1  |................|
-000062d0  82 d0 b8 d1 80 d0 b0 d1  9a d0 b5 e2 88 bc e2 88  |................|
-000062e0  bc d1 82 d0 b5 d1 81 d1  82 d0 b8 d1 80 d0 b0 d1  |................|
-000062f0  9a d0 b5 e2 88 bc e2 88  bc 4d 6f 68 35 7a 61 e2  |.........Moh5za.|
-00006300  88 bc e2 88 bc 00 00 00  13 00 00 00 ec 00 61 01  |..............a.|
-00006310  e2 88 bc e2 88 bc 38 e2  88 bc e2 88 bc d1 82 d0  |......8.........|
-00006320  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00006330  88 bc e2 88 bc d1 82 d0  b5 d1 81 d1 82 d0 b8 d1  |................|
-00006340  80 d0 b0 d1 9a d0 b5 e2  88 bc e2 88 bc d1 82 d0  |................|
-00006350  b5 d1 81 d1 82 d0 b8 d1  80 d0 b0 d1 9a d0 b5 e2  |................|
-00006360  88 bc e2 88 bc 4d 6f 68  35 7a 61 e2 88 bc e2 88  |.....Moh5za.....|
-00006370  bc 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-00006380  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-000063f0  00 00 00 00 00 00 00 00  0c 00 00 de 30 40 16 b7  |............0@..|
-00006400  00 00 00 00 44 01 05 01  31 31 38 78 2d 00 00 00  |....D...118x-...|
-00006410  0c 00 03 01 32 78 2d d0  0e 00 00 00 0c 00 03 01  |....2x-.........|
-00006420  33 78 2d d1 0f 00 00 00  0c 00 03 01 34 78 2d d0  |3x-.........4x-.|
-00006430  11 00 00 00 0c 00 03 01  36 78 2d d1 14 00 00 00  |........6x-.....|
-00006440  0c 00 03 01 39 78 2d d0  16 00 00 00 0c 00 04 01  |....9x-.........|
-00006450  31 31 78 2d 18 00 00 00  0c 00 04 01 31 33 78 2d  |11x-........13x-|
-00006460  19 00 00 00 0c 00 04 01  31 34 78 2d 1a 00 00 00  |........14x-....|
-00006470  0c 00 04 01 31 35 78 2d  1b 00 00 00 0c 00 04 01  |....15x-........|
-00006480  31 36 78 2d 1c 00 00 00  0c 00 04 01 31 37 78 2d  |16x-........17x-|
-00006490  1e 00 00 00 0c 00 04 01  31 39 78 2d 1f 00 00 00  |........19x-....|
-000064a0  0c 00 04 01 32 30 78 2d  20 00 00 00 0c 00 04 01  |....20x- .......|
-000064b0  32 31 78 2d 21 00 00 00  0c 00 04 01 32 32 78 2d  |21x-!.......22x-|
-000064c0  23 00 00 00 0c 00 04 01  32 34 78 2d 25 00 00 00  |#.......24x-%...|
-000064d0  0c 00 04 01 32 36 78 2d  26 00 00 00 0c 00 04 01  |....26x-&.......|
-000064e0  32 37 78 2d 28 00 00 00  0c 00 04 01 32 39 78 2d  |27x-(.......29x-|
-000064f0  29 00 00 00 0c 00 04 01  33 30 78 2d 2b 00 00 00  |).......30x-+...|
-00006500  0c 00 04 01 33 32 78 2d  2d 00 00 00 0c 00 04 01  |....32x--.......|
-00006510  33 34 78 2d 30 00 00 00  0c 00 04 01 33 37 78 2d  |34x-0.......37x-|
-00006520  31 00 00 00 0c 00 04 01  33 38 78 2d 32 00 00 00  |1.......38x-2...|
-00006530  0c 00 04 01 33 39 78 2d  34 00 00 00 0c 00 04 01  |....39x-4.......|
-00006540  34 31 78 2d 0b 00 00 00  b0 02 0a 02 6c 6f 73 74  |41x-........lost|
-00006550  2b 66 6f 75 6e 64 00 00  37 00 00 00 0c 00 04 01  |+found..7.......|
-00006560  34 34 78 2d 38 00 00 00  0c 00 04 01 34 35 78 2d  |44x-8.......45x-|
-00006570  39 00 00 00 0c 00 04 01  34 36 78 2d 3a 00 00 00  |9.......46x-:...|
-00006580  0c 00 04 01 34 37 78 2d  3b 00 00 00 0c 00 04 01  |....47x-;.......|
-00006590  34 38 78 2d 3e 00 00 00  0c 00 04 01 35 31 78 2d  |48x->.......51x-|
-000065a0  3f 00 00 00 0c 00 04 01  35 32 78 2d 41 00 00 00  |?.......52x-A...|
-000065b0  0c 00 04 01 35 34 78 2d  44 00 00 00 0c 00 04 01  |....54x-D.......|
-000065c0  35 37 78 2d 46 00 00 00  0c 00 04 01 35 39 78 2d  |57x-F.......59x-|
-000065d0  47 00 00 00 0c 00 04 01  36 30 78 2d 49 00 00 00  |G.......60x-I...|
-000065e0  0c 00 04 01 36 32 78 2d  4a 00 00 00 0c 00 04 01  |....62x-J.......|
-000065f0  36 33 78 2d 4b 00 00 00  0c 00 04 01 36 34 78 2d  |63x-K.......64x-|
-00006600  4e 00 00 00 0c 00 04 01  36 37 78 2d 52 00 00 00  |N.......67x-R...|
-00006610  0c 00 04 01 37 31 78 2d  55 00 00 00 0c 00 04 01  |....71x-U.......|
-00006620  37 34 78 2d 56 00 00 00  0c 00 04 01 37 35 78 2d  |74x-V.......75x-|
-00006630  57 00 00 00 0c 00 04 01  37 36 78 2d 58 00 00 00  |W.......76x-X...|
-00006640  0c 00 04 01 37 37 78 2d  59 00 00 00 0c 00 04 01  |....77x-Y.......|
-00006650  37 38 78 2d 5a 00 00 00  0c 00 04 01 37 39 78 2d  |78x-Z.......79x-|
-00006660  5b 00 00 00 0c 00 04 01  38 30 78 2d 5d 00 00 00  |[.......80x-]...|
-00006670  0c 00 04 01 38 32 78 2d  5e 00 00 00 0c 00 04 01  |....82x-^.......|
-00006680  38 33 78 2d 5f 00 00 00  0c 00 04 01 38 34 78 2d  |83x-_.......84x-|
-00006690  60 00 00 00 0c 00 04 01  38 35 78 2d 61 00 00 00  |`.......85x-a...|
-000066a0  0c 00 04 01 38 36 78 2d  62 00 00 00 0c 00 04 01  |....86x-b.......|
-000066b0  38 37 78 2d 64 00 00 00  0c 00 04 01 38 39 78 2d  |87x-d.......89x-|
-000066c0  65 00 00 00 0c 00 04 01  39 30 78 2d 69 00 00 00  |e.......90x-i...|
-000066d0  0c 00 04 01 39 34 78 2d  6a 00 00 00 0c 00 04 01  |....94x-j.......|
-000066e0  39 35 78 2d 6b 00 00 00  0c 00 04 01 39 36 78 2d  |95x-k.......96x-|
-000066f0  6c 00 00 00 0c 00 04 01  39 37 78 2d 6d 00 00 00  |l.......97x-m...|
-00006700  0c 00 04 01 39 38 78 2d  6e 00 00 00 0c 00 04 01  |....98x-n.......|
-00006710  39 39 78 2d 6f 00 00 00  10 00 05 01 31 30 30 78  |99x-o.......100x|
-00006720  2d 00 00 00 70 00 00 00  10 00 05 01 31 30 31 78  |-...p.......101x|
-00006730  2d 00 00 00 72 00 00 00  10 00 05 01 31 30 33 78  |-...r.......103x|
-00006740  2d 00 00 00 73 00 00 00  10 00 05 01 31 30 34 78  |-...s.......104x|
-00006750  2d 00 00 00 75 00 00 00  10 00 05 01 31 30 36 78  |-...u.......106x|
-00006760  2d 00 00 00 76 00 00 00  10 00 05 01 31 30 37 78  |-...v.......107x|
-00006770  2d 00 00 00 77 00 00 00  10 00 05 01 31 30 38 78  |-...w.......108x|
-00006780  2d 00 00 00 78 00 00 00  10 00 05 01 31 30 39 78  |-...x.......109x|
-00006790  2d 00 00 00 7a 00 00 00  10 00 05 01 31 31 31 78  |-...z.......111x|
-000067a0  2d 00 00 00 7b 00 00 00  10 00 05 01 31 31 32 78  |-...{.......112x|
-000067b0  2d 00 00 00 7e 00 00 00  10 00 05 01 31 31 35 78  |-...~.......115x|
-000067c0  2d e6 a9 53 80 00 00 00  30 00 05 01 31 31 37 78  |-..S....0...117x|
-000067d0  2d 83 01 66 8c 00 6c 00  2a 4c ce 8d a7 00 6c 00  |-..f..l.*L....l.|
-000067e0  8e 47 bc ac 56 00 6c 00  f8 7b c2 b3 00 00 14 00  |.G..V.l..{......|
-000067f0  b4 28 97 e4 00 00 00 00  0c 00 00 de 78 b2 28 ec  |.(..........x.(.|
-00006800  ff 07 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-00006810  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
-*
-00006c00  00 00 00 00 03 00 00 00  04 00 00 00 05 00 00 00  |................|
-00006c10  06 00 00 00 07 00 00 00  08 00 00 00 09 00 00 00  |................|
-00006c20  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
-*
-00007530
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,00717528 s, 3,5 GB/s
+[.] Create ext4 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
+[.] Create test files
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+total 21
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rw-r----- 1 root root     8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+drwx------ 2 root root 12288 Nov 18 19:22 lost+found
+[.] Delete all test files
+total 12
+drwx------ 2 root root 12288 Nov 18 19:22 lost+found
+[.] run overwrite -meta:5000 -data:all -path:/tmp/testfs
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+100% 
+
+Time: 00:00:00.578 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+24+0 records in
+24+0 records out
+25165824 bytes (25 MB, 24 MiB) copied, 0,00714761 s, 3,5 GB/s
+[.] Create ntfs file system and mount
+/tmp/RAWdata is not a block device.
+mkntfs forced anyway.
+The sector size was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 512 bytes.
+The partition start sector was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of sectors per track was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of heads was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+To boot from a device, Windows needs the 'partition start sector', the 'sectors per track' and the 'number of heads' to be set.
+Windows will not be able to boot from this device.
+[.] Create test files
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+[.] test file name length: 46
+total 5
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼1∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼2∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼3∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼4∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼5∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼6∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼7∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼8∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+-rwxrwxrwx 1 root root 8 Nov 18 19:22 ∼∼9∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼
+[.] Delete all test files
+total 0
+[.] run overwrite -meta:70 -data:all -path:/tmp/testfs
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+100% 
+
+Time: 00:00:00.62 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
 [.] clean up

--- a/UlrichBerntien/04_ext4_file_names.sh
+++ b/UlrichBerntien/04_ext4_file_names.sh
@@ -1,53 +1,70 @@
 #!/usr/bin/env bash
+set -o nounset
 
 RAW='/tmp/RAWdata'
 FS='/tmp/testfs'
 
-if [[ $EUID != 0 ]]; then
-    echo "[!] mount/unmount operations needs root privilege"
+if [[ $EUID -ne 0 ]]; then
+    echo '[!] mount/unmount operations needs root privilege'
     exit
-fi
-if [[ ! -x ./overwrite ]]; then
-    ./load_overwrite.sh
-fi
-echo '[.] overwrite version'
-./overwrite --version
+fi    
+./load_overwrite.sh
 
-echo '[.] Create a small test drive'
-dd bs=1M count=1 if=/dev/zero "of=$RAW"
-echo '[.] Create ext4 file system with out JOURNAL'
-mkfs.ext4 -q "$RAW"
-tune2fs -l "$RAW"
-mkdir "$FS"
-mount "$RAW" "$FS"
-
-echo '[.] Create test files'
-for i in $(seq 9)
+for mkfs in 'fat' 'exfat' 'vfat' 'ext2' 'ext4' 'ntfs'
 do
-	testname="∼∼$i∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼"
-	echo "[.] test file name length: ${#testname}"
-    echo "content" > "$FS/$testname"
+    echo '[.] Create a small test drive'
+    dd bs=1M count=24 if=/dev/zero "of=$RAW"
+    echo "[.] Create $mkfs file system and mount"
+    if [[ "$mkfs" =~ 'ext' ]]; then
+        mkfs.$mkfs -q -O ^has_journal "$RAW"
+        tune2fs -l "$RAW" | grep -iE '(features|journal)'
+    elif [[ "$mkfs" == 'ntfs' ]]; then
+        mkfs.$mkfs -q -F "$RAW"
+    else
+        mkfs.$mkfs "$RAW"
+    fi
+    mkdir "$FS"
+    mount "$RAW" "$FS"
+
+    echo '[.] Create test files'
+    for i in $(seq 9)
+    do
+    	testname="∼∼$i∼∼тестирање∼∼тестирање∼∼тестирање∼∼Moh5za∼∼"
+    	echo "[.] test file name length: ${#testname}"
+        echo "content" > "$FS/$testname"
+    done
+    ls -l "$FS"
+    echo '[.] Delete all test files'
+    rm $FS/*∼Moh5za∼∼
+    ls -l "$FS"
+
+    if [[ "$mkfs" == 'ext4' ]]; then
+        # if "-meta:4000" is used then file name rests remain
+        OV_PARAMTERS=("-meta:5000" "-data:all" "-path:$FS")
+    else
+        # if "-meta:60" is used then file name rests remain
+        OV_PARAMTERS=("-meta:70" "-data:all" "-path:$FS")
+    fi
+    echo '[.] run overwrite' "${OV_PARAMTERS[@]}"
+    ./overwrite "${OV_PARAMTERS[@]}"
+
+    echo '[.] unmount the test file system'
+    umount "$FS"
+    # extract strings in 16-bit little endian 
+    strings -n 6 -e l $RAW > /tmp/strs
+
+    echo '[.] check the metadata'
+    if grep -qF Moh5za $RAW; then
+        echo '[X] file name rest found on test drive!'
+        hexdump -C $RAW | grep -F Moh5za
+    elif grep -qF Moh5za /tmp/strs; then
+        echo '[X] file name rest (2 byte charset) found on test drive!'
+        grep -F Moh5za /tmp/strs
+    else
+        echo '[O] test case passed. No file name rest found'
+    fi
+
+    echo '[.] clean up'
+    rm -rf "$FS"
+    rm "$RAW"
 done
-ls -l "$FS"
-echo '[.] Delete all test files'
-rm $FS/*∼Moh5za∼∼
-ls -l "$FS"
-
-OV_PARAMTERS=("-meta:9000" "-data:all" "-path:$FS")
-echo "[.] run overwrite with ${OV_PARAMTERS[@]}"
-./overwrite "${OV_PARAMTERS[@]}"
-
-echo '[.] unmount the test file system'
-umount "$FS"
-
-echo '[.] check the data on the test drive'
-if grep -qF 'Moh5za' "$RAW"; then
-    echo '[X] file name rest found on test drive!'
-    hexdump -C -n 30000 "$RAW" 
-else
-    echo '[O] passed. No file name rest found'
-fi
-
-echo '[.] clean up'
-rm -rf "$FS"
-rm "$RAW"

--- a/UlrichBerntien/05_random_names.log
+++ b/UlrichBerntien/05_random_names.log
@@ -1,0 +1,370 @@
+[.] overwrite version
+Overwrite Version 1.5.2 2019-11-16
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,52332 s, 2,1 GB/s
+[.] Create fat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:01:29.202 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,524287 s, 2,0 GB/s
+[.] Create exfat file system and mount
+mkexfatfs 1.2.8
+Creating... done.
+Flushing... done.
+File system created successfully.
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:00:03.202 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,525602 s, 2,0 GB/s
+[.] Create vfat file system and mount
+mkfs.fat 4.1 (2017-01-24)
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:01:28.964 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[O] test case passed. No file name rest found
+[.] clean up
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,526866 s, 2,0 GB/s
+[.] Create ext2 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype sparse_super large_file
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:00:02.18 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[X] file name rest found on test drive!
+302023e0  33 78 5a 74 4d 41 34 52  4b 69 00 00 33 c0 00 00  |3xZtMA4RKi..3...|
+30202440  14 00 02 01 34 78 59 4d  41 34 52 4b 70 58 00 00  |....4xYMA4RKpX..|
+30202530  14 00 02 01 35 78 6f 4c  30 4d 41 34 52 4b 00 00  |....5xoL0MA4RK..|
+30202570  36 78 48 4d 41 34 52 4b  30 75 00 00 47 c0 00 00  |6xHMA4RK0u..G...|
+[.] clean up
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,519665 s, 2,1 GB/s
+[.] Create ext4 file system and mount
+Filesystem features:      ext_attr resize_inode dir_index filetype extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:00:01.808 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[X] file name rest found on test drive!
+010973e0  33 78 5a 74 4d 41 34 52  4b 69 00 00 3e 00 00 00  |3xZtMA4RKi..>...|
+01097440  14 00 02 01 34 78 59 4d  41 34 52 4b 70 58 00 00  |....4xYMA4RKpX..|
+01097530  14 00 02 01 35 78 6f 4c  30 4d 41 34 52 4b 00 00  |....5xoL0MA4RK..|
+01097570  36 78 48 4d 41 34 52 4b  30 75 00 00 52 00 00 00  |6xHMA4RK0u..R...|
+[.] clean up
+[.] Create a small test drive
+1+0 records in
+1+0 records out
+1073741824 bytes (1,1 GB, 1,0 GiB) copied, 0,520237 s, 2,1 GB/s
+[.] Create ntfs file system and mount
+/tmp/RAWdata is not a block device.
+mkntfs forced anyway.
+The sector size was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 512 bytes.
+The partition start sector was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of sectors per track was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+The number of heads was not specified for /tmp/RAWdata and it could not be obtained automatically.  It has been set to 0.
+To boot from a device, Windows needs the 'partition start sector', the 'sectors per track' and the 'number of heads' to be set.
+Windows will not be able to boot from this device.
+[.] Create test directory
+[.] Create test files
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	I866MA4RKA  M3OZjU6HZm	raeTh1ahse  Uw1d2QVhLb
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	IeI6sNkKP8  M4vxzPYnTm	RDFPLjo0Rm  vhKw01jQ4S
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ierah3fohD  M5ZWQ3OEIg	rooG5Quaec  vlEznHk879
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	ieth1kaeF4  Mb4pV2CyAL	RZP2Z9RZKC  VpML5Qtyw6
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IJb7DIm96a  mc76QjKZ7X	s5EMuuXqMV  VQBIy0f9tU
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	IMwKxELn8R  MjBhMA4RKs	sealeiRi2a  VzYSNmSK3k
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	ITHMA4RK0u  MRNIE6TtEE	shohquieW0  wozuZ8heiN
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	j2tXwJU19e  o331MA4RKo	sL9lmrKxgN  wRW08PEt27
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	jieZa7oghu  OFIPWqh438	so68lBokzg  wWW36LOmFk
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GqZtMA4RKi	KAHKy8ZRnZ  ogai6ku5eK	SsOWqpyN5p  x53TBQk6Rf
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GsFtI7Qetl	KgAXv3dvdQ  OhQu6shaez	SUfrot5MnF  xNpoYh41Ek
+47oL0MA4RK  aeBee5begu	eCsViw6QBF  GU6jMIsHDs	kU5tkqjdyw  ohth2yi1Bu	tahpish4Re  yucUYj7V0Z
+4JyDf3TlXp  aeChuph9ei	Eedaz3teo0  gVixG6e6jn	L7pmmakbRZ  ooch6mooYe	TeiKooMei8  yYykZ54tUW
+58JNLBoHv6  AeODb2XVjC	eeGh6eijoh  Ha1OopXUuG	lE9ExUTPXg  p8c4LBRc6D	TJ1eCqdLNI  ZoC1CnJ1u9
+66uZXLwaI1  ahQ2MA4RK9	eeP6ahchei  Hci0j3W79R	li8eiXaeve  pcRRtx9Bua	TwxNw7SSyp
+6nJhAUxcQ5  ahz9Othat8	eev1quoo1O  HieZaihae1	looc2ohN4r  Phae1xiesa	TyzCRI2fhw
+74msnI0ZAt  Aid5ooGh1z	eeW3ein1os  hkb3D2B3K8	lPkg9PorXc  pvyaIxqg2V	UnH48DqsmM
+7GegdKJxKx  aS43k6KnOk	EhYMA4RKpX  hTeoALOr9w	LukM9a3auf  qG97Tku5AK	uokVK5KT0C
+[.] Delete some test files
+[.] directory content after delete
+0BhPNq12Y1  7j9PLugpMH	bk7aO0c0Fb  eip9eez8Re	IeI6sNkKP8  M4vxzPYnTm	rooG5Quaec  vhKw01jQ4S
+0eyVuHnebJ  8tSqzzu6li	cCsNL6JhdB  eipoV7Bo0W	ierah3fohD  M5ZWQ3OEIg	RZP2Z9RZKC  vlEznHk879
+0jrki44dXe  95nWsDoqiB	ceZovie2bu  eiVae0jahd	ieth1kaeF4  Mb4pV2CyAL	s5EMuuXqMV  VpML5Qtyw6
+0PqZPeM7nO  97HrO0ly4Z	chaif3eiCh  En3rgYOAYr	IJb7DIm96a  mc76QjKZ7X	sealeiRi2a  VQBIy0f9tU
+0vvDwdWx9N  9JKtURjBm1	civ1Uiphee  eos0OhRiez	IMwKxELn8R  MRNIE6TtEE	shohquieW0  VzYSNmSK3k
+1FrKaGmkM4  9k4ipu2tZS	DAi3BWcmiL  eph3Phin4i	j2tXwJU19e  OFIPWqh438	sL9lmrKxgN  wozuZ8heiN
+1tJKlTkly0  9Kip7Z7BY7	DaviuQu5ei  FaN3too5su	jieZa7oghu  ogai6ku5eK	so68lBokzg  wRW08PEt27
+205nxSzwQq  A72q8VME1M	dQj57Z0i4F  gD9Z8hIRcf	KAHKy8ZRnZ  OhQu6shaez	SsOWqpyN5p  wWW36LOmFk
+24PyvCG5VS  a9kzdOUOU5	dwwjTyR4ka  glZWG2uOct	KgAXv3dvdQ  ohth2yi1Bu	SUfrot5MnF  x53TBQk6Rf
+3yFlimDRQp  aa3ohyaeWu	DXRJ36wbLM  GsFtI7Qetl	kU5tkqjdyw  ooch6mooYe	tahpish4Re  xNpoYh41Ek
+40AUHIHWtv  aB5xRQJ0xo	dxz8Av0J7j  GU6jMIsHDs	L7pmmakbRZ  p8c4LBRc6D	TeiKooMei8  yucUYj7V0Z
+4JyDf3TlXp  aeBee5begu	eCsViw6QBF  gVixG6e6jn	lE9ExUTPXg  pcRRtx9Bua	TJ1eCqdLNI  yYykZ54tUW
+58JNLBoHv6  aeChuph9ei	Eedaz3teo0  Ha1OopXUuG	li8eiXaeve  Phae1xiesa	TwxNw7SSyp  ZoC1CnJ1u9
+66uZXLwaI1  AeODb2XVjC	eeGh6eijoh  Hci0j3W79R	looc2ohN4r  pvyaIxqg2V	TyzCRI2fhw
+6nJhAUxcQ5  ahz9Othat8	eeP6ahchei  HieZaihae1	lPkg9PorXc  qG97Tku5AK	UnH48DqsmM
+74msnI0ZAt  Aid5ooGh1z	eev1quoo1O  hkb3D2B3K8	LukM9a3auf  raeTh1ahse	uokVK5KT0C
+7GegdKJxKx  aS43k6KnOk	eeW3ein1os  hTeoALOr9w	M3OZjU6HZm  RDFPLjo0Rm	Uw1d2QVhLb
+[.] run overwrite -meta:9999 -data:all -path:/tmp/testfs/DIR1
+
+Writing metadata: 
+10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+Writing data: 
+1Gb 100% 
+
+Time: 00:00:03.533 
+Done. 
+[.] unmount the test file system
+[.] check the metadata
+[X] file name rest (2 byte charset) found on test drive!
+EhYMA4RKpX0
+GqZtMA4RKi
+[.] clean up

--- a/UlrichBerntien/05_random_names.sh
+++ b/UlrichBerntien/05_random_names.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -o nounset
+
+RAW='/tmp/RAWdata'
+FS='/tmp/testfs'
+
+# List of generated file names with pattern prepared in 8 names
+NAMES=(
+RZP2Z9RZKC TyzCRI2fhw GU6jMIsHDs 0PqZPeM7nO kU5tkqjdyw M5ZWQ3OEIg 1FrKaGmkM4
+vhKw01jQ4S GsFtI7Qetl 9Kip7Z7BY7 4JyDf3TlXp AeODb2XVjC lE9ExUTPXg SsOWqpyN5p
+dwwjTyR4ka glZWG2uOct wWW36LOmFk 0vvDwdWx9N 74msnI0ZAt IJb7DIm96a aB5xRQJ0xo
+OFIPWqh438 40AUHIHWtv 1tJKlTkly0 A72q8VME1M M4vxzPYnTm 0eyVuHnebJ 9JKtURjBm1
+MRNIE6TtEE SUfrot5MnF p8c4LBRc6D pvyaIxqg2V hTeoALOr9w IeI6sNkKP8 mc76QjKZ7X
+Uw1d2QVhLb En3rgYOAYr 6nJhAUxcQ5 MjBhMA4RKs lPkg9PorXc 8tSqzzu6li LukM9a3auf
+I866MA4RKA M3OZjU6HZm 58JNLBoHv6 gVixG6e6jn j2tXwJU19e x53TBQk6Rf GqZtMA4RKi
+yYykZ54tUW Mb4pV2CyAL cCsNL6JhdB DXRJ36wbLM EhYMA4RKpX pcRRtx9Bua sL9lmrKxgN
+IMwKxELn8R Hci0j3W79R dQj57Z0i4F hkb3D2B3K8 Ha1OopXUuG KgAXv3dvdQ gD9Z8hIRcf
+7j9PLugpMH 95nWsDoqiB 47oL0MA4RK TJ1eCqdLNI TwxNw7SSyp ITHMA4RK0u DAi3BWcmiL
+66uZXLwaI1 s5EMuuXqMV vlEznHk879 VzYSNmSK3k RDFPLjo0Rm 0jrki44dXe uokVK5KT0C
+7GegdKJxKx VQBIy0f9tU ZoC1CnJ1u9 eCsViw6QBF a9kzdOUOU5 so68lBokzg 3yFlimDRQp
+wRW08PEt27 UnH48DqsmM L7pmmakbRZ xNpoYh41Ek 9k4ipu2tZS 205nxSzwQq 24PyvCG5VS
+yucUYj7V0Z KAHKy8ZRnZ VpML5Qtyw6 97HrO0ly4Z bk7aO0c0Fb 0BhPNq12Y1 dxz8Av0J7j
+aS43k6KnOk qG97Tku5AK ohth2yi1Bu eeGh6eijoh eeP6ahchei aa3ohyaeWu eiVae0jahd
+ierah3fohD o331MA4RKo OhQu6shaez HieZaihae1 ooch6mooYe raeTh1ahse ieth1kaeF4
+eeW3ein1os eos0OhRiez eip9eez8Re aeBee5begu ahz9Othat8 looc2ohN4r jieZa7oghu
+TeiKooMei8 DaviuQu5ei aeChuph9ei ahQ2MA4RK9 rooG5Quaec chaif3eiCh shohquieW0
+civ1Uiphee Aid5ooGh1z ceZovie2bu ogai6ku5eK li8eiXaeve Eedaz3teo0 FaN3too5su
+eev1quoo1O Phae1xiesa wozuZ8heiN sealeiRi2a tahpish4Re eph3Phin4i eipoV7Bo0W)
+
+# The part in 8 of the NAMES
+PATTERN='MA4RK'
+
+if [[ $EUID -ne 0 ]]; then
+    echo '[!] mount/unmount operations needs root privilege'
+    exit
+fi    
+./load_overwrite.sh
+
+# check some file systems
+for mkfs in 'fat' 'exfat' 'vfat' 'ext2' 'ext4' 'ntfs'
+do
+    echo '[.] Create a small test drive'
+    dd bs=1G count=1 if=/dev/zero "of=$RAW"
+    echo "[.] Create $mkfs file system and mount"
+    if [[ "$mkfs" =~ 'ext' ]]; then
+        # ext4 file system with outjournal, see overwrite documentation
+        mkfs.$mkfs -q -O ^has_journal "$RAW"
+        tune2fs -l "$RAW" | grep -iE '(features|journal)'
+    elif [[ "$mkfs" == 'ntfs' ]]; then
+        # need force switch to generate NTFS in a file
+        mkfs.$mkfs -q -F "$RAW"
+    else
+        mkfs.$mkfs "$RAW"
+    fi
+    mkdir "$FS"
+    mount "$RAW" "$FS"
+
+    echo '[.] Create test directory'
+    mkdir "$FS/DIR1/"
+    echo '[.] Create test files'
+    for i in "${NAMES[@]}"
+    do
+        echo "content" > "$FS/DIR1/$i"
+    done
+    ls -C -w 100 "$FS/DIR1"
+    echo '[.] Delete some test files'
+    rm $FS/DIR1/*${PATTERN}*
+    echo '[.] directory content after delete'
+    ls -C -w 100 "$FS/DIR1"
+
+    OV_PARAMTERS=("-meta:9999" "-data:all" "-path:$FS/DIR1")
+    echo '[.] run overwrite' "${OV_PARAMTERS[@]}"
+    ./overwrite "${OV_PARAMTERS[@]}"
+
+    echo '[.] unmount the test file system'
+    umount "$FS"
+    # extract strings in 16-bit little endian 
+    strings -n 5 -e l $RAW > /tmp/strs
+
+    echo '[.] check the metadata'
+    if grep -qF "$PATTERN" "$RAW"; then
+        echo '[X] file name rest found on test drive!'
+        hexdump -C $RAW | grep -F "$PATTERN"
+    elif grep -qF "$PATTERN" /tmp/strs; then
+        echo '[X] file name rest (2 byte charset) found on test drive!'
+        grep -F "$PATTERN" /tmp/strs
+    else
+        echo '[O] test case passed. No file name rest found'
+    fi
+
+    echo '[.] clean up'
+    rm -rf "$FS"
+    rm "$RAW"
+done

--- a/UlrichBerntien/README.md
+++ b/UlrichBerntien/README.md
@@ -85,6 +85,21 @@ On the ext4 file system without journal overwrite must call with -meta:5000
 to overwrite the 9 test file names. (A call with parameter -meta:4000 is not
 sufficient to overwrite all test file names.)
 
+**05_random_names**
+
+In this test case a directory is created. In the directory 140 files are created.
+All file names are 10 character long.
+
+From this 140 files 8 files are deleted. The names of the 8 files were prepared
+with a string 'MA4RK' inside the 10 character long file name.
+
+The overwrite program with options -meta:9999 -data:all is called to overwrite
+the 8 deleted files with 9999 metadata entries.
+
+Overwrite version 1.5.2 does overwrite all names in the FAT file system but not
+in the ext3, ext4 with out journal and NTFS. Rest of the deleted files names
+are readable after the overwrite call.
+
 ## Support files
 
 **load_overwrite.sh**

--- a/UlrichBerntien/README.md
+++ b/UlrichBerntien/README.md
@@ -19,14 +19,15 @@ The files ".log" are output of the script files.
 
 **00_test_same_directory**
 
-Overwrite Version 1.0 2019-10-04 creates the file in a subdirectory.
+Overwrite version 1.0 2019-10-04 creates the file in a subdirectory.
 So only one directory entry in the given path was overwritten.
 
 Newer versins passes the test. All directory entries are overwritten.
 
+Overwrite version 1.5.2 passes this test case.
+
 **01_test_short_names**
 
-The test uses the FAT file system.
 The test script creates 2 test files with short names and deletes the 2nd test file.
 The overwrite call should overwrite the metadata of the 1st test file.
 
@@ -34,11 +35,13 @@ Overwrite ver1.2-2019-10-28 create files with long names.
 So the directory entry with short name inside the directory
 list was not overwritten.
 
-Overwrite Version 1.3.1 2019-10-30 uses short directory names to
+Overwrite version 1.3.1 2019-10-30 uses short directory names to
 overwrite entries. This works well.
 
-The Test failed with overwrite Version 1.5 2019-11-09 and 1.5.1 2019-11-14.
+The Test failed with overwrite version 1.5 2019-11-09 and 1.5.1 2019-11-14.
 The first directory entry is not overwritten.
+
+Overwrite version 1.5.2 passes this test case.
 
 **02_test_overflow**
 
@@ -51,6 +54,8 @@ An error message reports invalid names given as parameter.
 
 Overwrite version 1.5.1 2019-11-14 raises a memory segmentation fault.
 
+Overwrite version 1.5.2 passes this test case.
+
 **03_test_unix_names**
 
 Overwrite version 1.4.1 2019-11-03 handles path names with ':' and
@@ -62,13 +67,23 @@ Newer versions handels path names with ':' and '/' at the end.
 Overwrite passes the test if absolute path names are used to prevent
 a path name starting with a space.
 
+Overwrite version 1.5.2 passes this test case.
+
 **04_ext4_file_names**
 
 The test uses an ext4 file system with out journal on a small volume.
 The test creates 9 file, removes the files and calls overwrite.
 
+The ext4 file system with journal is not tested.
+See the overwrite documentation to handle ext with journal.
+
 The overwrite version 1.5.1 2019-11-14 does not remove all parts of the
 file names from the volume.
+
+Overwrite version 1.5.2 passes this test case.
+On the ext4 file system without journal overwrite must call with -meta:5000
+to overwrite the 9 test file names. (A call with parameter -meta:4000 is not
+sufficient to overwrite all test file names.)
 
 ## Support files
 

--- a/UlrichBerntien/load_overwrite.sh
+++ b/UlrichBerntien/load_overwrite.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
+set -o nounset
+set -o errexit
 
-echo "[.] Get overwrite program"
-curl -s -o overwrite.c https://raw.githubusercontent.com/ivoprogram/overwrite/master/c/overwrite.c
-echo "[.] Head of the source file with version info"
-head overwrite.c
-echo "[.] Compile overwrite program"
-gcc overwrite.c -o overwrite
-echo "[.] Hashes for version compare"
-md5sum overwrite*
-echo "[.] used test system"
-uname -a
-if [[ -r /etc/os-release ]]; then
-    grep PRETTY /etc/os-release
+if [[ ! -x ./overwrite ]]; then
+    echo '[.] Get overwrite program'
+    curl -s -o overwrite.c https://raw.githubusercontent.com/ivoprogram/overwrite/master/c/overwrite.c
+    echo '[.] Head of the source file'
+    head overwrite.c
+    echo '[.] Compile overwrite program'
+    gcc overwrite.c -o overwrite
+    echo '[.] SHA-1 hashes for version compare'
+    sha1sum overwrite*
+    echo '[.] used test system'
+    uname -a
+    if [[ -r /etc/os-release ]]; then
+        grep PRETTY /etc/os-release
+    fi
 fi
+
+echo -n '[.] overwrite version'
+./overwrite --version

--- a/UlrichBerntien/run_all.sh
+++ b/UlrichBerntien/run_all.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
+set -o nounset
 
 # load and compile the overwrite program
 echo '[.] load and compile overwrite'
 ./load_overwrite.sh > system.log 2>&1
 
 # run all test cases
-for shf in ./??_*.sh
+for test_script in ./??_*.sh
 do
-    echo "[.] run test script $shf"
-    if [[ -x "$shf" ]]; then
-        "./$shf" > "${shf/\.sh/.log}" 2>&1
+    echo "[.] run test script $test_script"
+    if [[ -x "$test_script" ]]; then
+        "./$test_script" > "${test_script/\.sh/.log}" 2>&1
         if [[ -a /tmp/testfs ]]; then
-            echo "[!] /tmp/testfs exists, no clean script exit"
+            echo '[!] /tmp/testfs exists, no clean script exit'
         fi
     fi
 done

--- a/UlrichBerntien/system.log
+++ b/UlrichBerntien/system.log
@@ -1,5 +1,5 @@
 [.] Get overwrite program
-[.] Head of the source file with version info
+[.] Head of the source file
 
 /*
 TITLE:			Overwrite Program
@@ -8,12 +8,14 @@ CODE:			github.com/ivoprogram/overwrite
 LICENSE:		GNU General Public License v3.0 http://www.gnu.org/licenses/gpl.html
 AUTHOR:			Ivo Gjorgjievski
 WEBSITE:		ivoprogram.github.io
-VERSION:		1.5.1 2019-11-14
+VERSION:		1.5.2 2019-11-16
 
 [.] Compile overwrite program
-[.] Hashes for version compare
-91b91ab5e7313b697ee269b3c9cbdf4b  overwrite
-7d944a39c202463a3900fc9808972ed3  overwrite.c
+[.] SHA-1 hashes for version compare
+16d9c048d30391355b5d4a97fedcfd517bfcc6d1  overwrite
+8c948e8e8093fa5acbc3dc5702f0ca6c8c82d34b  overwrite.c
 [.] used test system
 Linux Gate1.home.arpa 5.0.0-31-generic #33~18.04.1-Ubuntu SMP Tue Oct 1 10:20:39 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
 PRETTY_NAME="Ubuntu 18.04.3 LTS"
+[.] overwrite version
+Overwrite Version 1.5.2 2019-11-16


### PR DESCRIPTION
The overwrite version 1.5.2 program passes all old test cases.

A new test case 05 is not passed.
In the script the same test is executed with fat, ext4 (without journal) and ntfs. The files names are removed in the fat filesystem but not all parts of the names in the ext4 and ntfs filesystem are removed. (The files names are 10 character long and -meta:9999 was used.)